### PR TITLE
Bugfix/tabix destroy hash

### DIFF
--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -144,6 +144,7 @@ Bio::DB::HTS::Tabix - Object oriented access to the underlying tbx C methods
     while ( my $n = $iter->next ) {
         say $n;
     }
+    $tabix->close;
 
 =head1 DESCRIPTION
 

--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -121,11 +121,7 @@ sub close {
     }
 }
 
-sub DESTROY {
-     my $self = shift;
-     $self->close();
-     return;
-}
+
 
 1;
 

--- a/lib/Bio/DB/HTS/Tabix/Iterator.pm
+++ b/lib/Bio/DB/HTS/Tabix/Iterator.pm
@@ -66,11 +66,6 @@ sub close {
     }
 }
 
-sub DESTROY {
-     my $self = shift;
-     $self->close();
-     return;
-}
 
 1;
 


### PR DESCRIPTION
It looks like the close call in the DESTROY had issues. These remained even when the explicit call to close was removed in the test script, so I've taken the destroy out, and added the close call to the documentation as it should have been. But, not sure why the hash referencing problem was arising at that stage in the first place.
https://github.com/Ensembl/Bio-HTS/issues/17

Thoughts @andrewyatz @keiranmraine ?
