### PR TITLE
Adding DESTROY back in with a HASH ref check

### DIFF
--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -121,6 +121,12 @@ sub close {
     }
 }
 
+sub DESTROY {
+    my $self = shift;
+    return if ref($self) ne 'HASH';
+    $self->close();
+    return;
+}
 
 
 1;

--- a/lib/Bio/DB/HTS/Tabix/Iterator.pm
+++ b/lib/Bio/DB/HTS/Tabix/Iterator.pm
@@ -66,6 +66,12 @@ sub close {
     }
 }
 
+sub DESTROY {
+    my $self = shift;
+    return if ref($self) ne 'HASH';
+    $self->close();
+    return;
+}
 
 1;
 


### PR DESCRIPTION
The previous attempt at this did not do a HASH ref check. We need to do
this because there is an XS object in the same namespace as these two
objects. It is a little confusing but this seems to be okay. The main
thing is we do the check and we know we're working with the Perl object
and can issue the close() to cleanup the objects.
