### PR TITLE
Bugfix/free str with no return

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+1.14 (in progress)
+   * Tabix bugfix: see GitHub issue #17
 
 1.13
    * removed file existence Tabix check as it prevents remote access

--- a/lib/Bio/DB/HTS.xs
+++ b/lib/Bio/DB/HTS.xs
@@ -1305,11 +1305,14 @@ tabix_tbx_iter_next(iter, fp, t)
   PREINIT:
     kstring_t str = {0,0,0};
   CODE:
-    if (tbx_itr_next(fp, t, iter, &str) < 0)
+    if (tbx_itr_next(fp, t, iter, &str) < 0) {
+        free(str.s);
         XSRETURN_EMPTY;
+    }
 
     RETVAL = newSVpv(str.s, str.l);
     free(str.s);
+
   OUTPUT:
     RETVAL
 


### PR DESCRIPTION
XSRETURN_EMPTY was bailing from the subroutine before we could clean up the struct.
