### PR TITLE
Use reftype() not ref() to find the underlying structure a ref points at

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,5 @@
 1.14 (in progress)
-   * Tabix bugfix: see GitHub issue #17
+   * Tabix bugfixes: see GitHub issue #17
 
 1.13
    * removed file existence Tabix check as it prevents remote access

--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -25,6 +25,7 @@ $Bio::DB::HTS::Tabix::VERSION = '1.13';
 use strict;
 use warnings;
 
+use Scalar::Util qw/reftype/;
 
 sub new {
   my $class         = shift;
@@ -123,7 +124,7 @@ sub close {
 
 sub DESTROY {
     my $self = shift;
-    return if ref($self) ne 'HASH';
+    return if reftype($self) ne 'HASH';
     $self->close();
     return;
 }

--- a/lib/Bio/DB/HTS/Tabix/Iterator.pm
+++ b/lib/Bio/DB/HTS/Tabix/Iterator.pm
@@ -23,6 +23,7 @@ $Bio::DB::HTS::Tabix::Iterator::VERSION = '1.13';
 
 use strict;
 use warnings;
+use Scalar::Util qw/reftype/;
 
 #this class is just a wrapper around the tabix_iter_next method,
 #all the attributes it needs come from the main Tabix method
@@ -68,7 +69,7 @@ sub close {
 
 sub DESTROY {
     my $self = shift;
-    return if ref($self) ne 'HASH';
+    return if reftype($self) ne 'HASH';
     $self->close();
     return;
 }


### PR DESCRIPTION
Final fix. Final memory leak?
