### PR TITLE
Adding lzma, libbz2 and curl dev libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ addons:
     apt:
         packages:
         - unzip
+        - liblzma-dev
+        - libbz2-dev
+        - libcurl-dev
 
 before_install:
     - git clone -b bioperl-release-1-6-1 --depth 1 https://github.com/bioperl/bioperl-live.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
         packages:
         - unzip
         - liblzma-dev
-        - libbz2-dev
-        - libcurl-dev
 
 before_install:
     - git clone -b bioperl-release-1-6-1 --depth 1 https://github.com/bioperl/bioperl-live.git


### PR DESCRIPTION
Test currently fails because it lacks lzma.h. I assume it'll start to fail because it will lack bz2 and curl headers.