### PR TITLE
Add DESTROY methods for guaranteed resources dealloction

### DIFF
--- a/lib/Bio/DB/HTS.pm
+++ b/lib/Bio/DB/HTS.pm
@@ -1337,7 +1337,6 @@ sub new {
                        autoindex     => $autoindex,
                        force_refseq  => $force_refseq, },
       ref $class || $class;
-    my $b = $self->{hts_file};
     $self->header;    # catch it
     return $self;
 } ## end sub new

--- a/lib/Bio/DB/HTS.xs
+++ b/lib/Bio/DB/HTS.xs
@@ -69,7 +69,9 @@ typedef tbx_t*          Bio__DB__HTS__Tabix;
 typedef hts_itr_t*      Bio__DB__HTS__Tabix__Iterator;
 typedef vcfFile*        Bio__DB__HTS__VCFfile;
 typedef bcf_hdr_t*      Bio__DB__HTS__VCF__Header;
+typedef bcf_hdr_t*      Bio__DB__HTS__VCF__HeaderPtr;
 typedef bcf1_t*         Bio__DB__HTS__VCF__Row;
+typedef bcf1_t*         Bio__DB__HTS__VCF__RowPtr;
 KSEQ_INIT(gzFile, gzread)
 typedef gzFile          Bio__DB__HTS__Kseq;
 typedef kseq_t*         Bio__DB__HTS__Kseq__Iterator;
@@ -371,7 +373,7 @@ fai_load(packname="Bio::DB::HTS::Fai", filename)
     RETVAL
 
 void
-fai_destroy(fai)
+fai_DESTROY(fai)
   Bio::DB::HTS::Fai fai
   PROTOTYPE: $
   CODE:
@@ -433,7 +435,7 @@ hts_open(packname, filename, mode="r")
 
 
 void
-hts_close(htsfile)
+hts_DESTROY(htsfile)
    Bio::DB::HTSfile   htsfile
 PROTOTYPE: $
 CODE:
@@ -458,15 +460,6 @@ hts_index_load(packname, htsfile)
       RETVAL = sam_index_load(htsfile, htsfile->fn) ;
     OUTPUT:
       RETVAL
-
-void
-hts_index_close(indexfile)
-           Bio::DB::HTS::Index indexfile
-    PROTOTYPE: $$
-    CODE:
-      hts_idx_destroy(indexfile) ;
-
-
 
 Bio::DB::HTS::Header
 hts_header_read(htsfile)
@@ -1173,7 +1166,7 @@ OUTPUT:
 
 
 void
-bami_close(hts_idx)
+bami_DESTROY(hts_idx)
   Bio::DB::HTS::Index hts_idx
   CODE:
     hts_idx_destroy(hts_idx) ;
@@ -1280,7 +1273,6 @@ tabix_tbx_close(t)
     Bio::DB::HTS::Tabix t
   CODE:
     tbx_destroy(t);
-  OUTPUT:
 
 Bio::DB::HTS::Tabix::Iterator
 tabix_tbx_query(t, region)
@@ -1439,6 +1431,8 @@ vcf_file_num_variants(packname,filename)
         {
             ++n_records;
         }
+        bcf_destroy(rec);
+        bcf_hdr_destroy(h);
         bcf_close(vfile) ;
         RETVAL = newSViv(n_records);
     OUTPUT:
@@ -1447,16 +1441,18 @@ vcf_file_num_variants(packname,filename)
 
 
 void
-vcf_file_vcf_close(vfile,h)
+vcf_file_vcf_close(vfile)
     Bio::DB::HTS::VCFfile vfile
-    Bio::DB::HTS::VCF::Header h
     CODE:
-        bcf_hdr_destroy(h);
         bcf_close(vfile);
-    OUTPUT:
 
 MODULE = Bio::DB::HTS PACKAGE = Bio::DB::HTS::VCF::Header PREFIX = vcfh_
 
+void
+vcfh_DESTROY(h)
+    Bio::DB::HTS::VCF::Header h
+    CODE:
+        bcf_hdr_destroy(h);
 
 SV*
 vcfh_version(header)
@@ -1938,19 +1934,11 @@ vcfrow_get_genotypes(row,header)
   OUTPUT:
       RETVAL
 
-
-
-
-
 void
-vcfrow_destroy(packname, row)
-    char* packname
+vcfrow_DESTROY(row)
     Bio::DB::HTS::VCF::Row row
     CODE:
       bcf_destroy(row);
-    OUTPUT:
-
-
 
 MODULE = Bio::DB::HTS PACKAGE = Bio::DB::HTS::VCF::Sweep PREFIX = vcfs_
 
@@ -1965,7 +1953,7 @@ vcfs_sweep_open(filename)
     OUTPUT:
         RETVAL
 
-Bio::DB::HTS::VCF::Header
+Bio::DB::HTS::VCF::HeaderPtr
 vcfs_header_read(sweep)
     Bio::DB::HTS::VCF::Sweep sweep
     PREINIT:
@@ -1976,7 +1964,7 @@ vcfs_header_read(sweep)
     OUTPUT:
         RETVAL
 
-Bio::DB::HTS::VCF::Row
+Bio::DB::HTS::VCF::RowPtr
 vcfs_sweep_next(sweep)
     Bio::DB::HTS::VCF::Sweep sweep
     PREINIT:
@@ -1994,7 +1982,7 @@ vcfs_sweep_next(sweep)
     OUTPUT:
         RETVAL
 
-Bio::DB::HTS::VCF::Row
+Bio::DB::HTS::VCF::RowPtr
 vcfs_sweep_previous(sweep)
     Bio::DB::HTS::VCF::Sweep sweep
     PREINIT:

--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -136,11 +136,6 @@ sub header_array {
 sub close {
     my $self = shift;
 
-    if ( $self->{_htsfile} ) {
-        Bio::DB::HTSfile::close($self->{_htsfile});
-        delete $self->{_htsfile};
-    }
-
     if ( $self->{_tabix_index} ) {
         tbx_close($self->{_tabix_index});
         delete $self->{_tabix_index};

--- a/lib/Bio/DB/HTS/VCF.pm
+++ b/lib/Bio/DB/HTS/VCF.pm
@@ -154,6 +154,7 @@ package Bio::DB::HTS::VCF;
 $Bio::DB::HTS::VCF::VERSION = '2.7';
 
 use Bio::DB::HTS;
+use Scalar::Util qw/reftype/;
 use strict;
 use warnings;
 use Carp 'croak';
@@ -202,14 +203,23 @@ sub close
     my $self = shift;
     if ( $self->{vcf_file} )
     {
-        $self->{vcf_file}->vcf_close($self->{header});
+        $self->{vcf_file}->vcf_close();
+        delete $self->{vcf_file};
     }
+}
+
+sub DESTROY {
+    my $self = shift;
+    return if reftype($self) ne 'HASH';
+    $self->close();
+    return;
 }
 
 package Bio::DB::HTS::VCF::Sweep ;
 $Bio::DB::HTS::VCF::Sweep::VERSION = '2.7';
 
 use Bio::DB::HTS;
+use Scalar::Util qw/reftype/;
 use strict;
 use warnings;
 
@@ -259,7 +269,15 @@ sub close
     if ( $self->{sweep} )
     {
         sweep_close($self->{sweep});
+        delete $self->{sweep};
     }
+}
+
+sub DESTROY {
+    my $self = shift;
+    return if reftype($self) ne 'HASH';
+    $self->close();
+    return;
 }
 
 1;

--- a/lib/Bio/DB/HTS/VCF/Header.pm
+++ b/lib/Bio/DB/HTS/VCF/Header.pm
@@ -1,0 +1,6 @@
+package Bio::DB::HTS::VCF::Header;
+
+use Bio::DB::HTS; #load the XS
+$Bio::DB::HTS::VCF::Header::VERSION = '2.7';
+
+1;

--- a/lib/Bio/DB/HTS/VCF/HeaderPtr.pm
+++ b/lib/Bio/DB/HTS/VCF/HeaderPtr.pm
@@ -1,0 +1,9 @@
+package Bio::DB::HTS::VCF::HeaderPtr;
+
+use base Bio::DB::HTS::VCF::Header;
+
+sub DESTROY {
+    # do nothing (overwrite subroutine in base class)
+}
+
+1;

--- a/lib/Bio/DB/HTS/VCF/Row.pm
+++ b/lib/Bio/DB/HTS/VCF/Row.pm
@@ -1,0 +1,6 @@
+package Bio::DB::HTS::VCF::Row;
+$Bio::DB::HTS::VCF::Row::VERSION = '2.7';
+
+use Bio::DB::HTS;
+
+1;

--- a/lib/Bio/DB/HTS/VCF/RowPtr.pm
+++ b/lib/Bio/DB/HTS/VCF/RowPtr.pm
@@ -1,0 +1,9 @@
+package Bio::DB::HTS::VCF::RowPtr;
+
+use base Bio::DB::HTS::VCF::Row;
+
+sub DESTROY {
+    # do nothing (overwrite subroutine in base class)
+}
+
+1;

--- a/t/05vcf.t
+++ b/t/05vcf.t
@@ -14,11 +14,17 @@
 
 use strict;
 use warnings;
-use Test::More tests => 109, 'die';
+use Test::More tests => 113, 'die';
 
 use FindBin qw( $Bin );
 
-BEGIN { use_ok 'Bio::DB::HTS::VCF'; }
+BEGIN {
+  use_ok 'Bio::DB::HTS::VCF';
+  use_ok 'Bio::DB::HTS::VCF::Row';
+  use_ok 'Bio::DB::HTS::VCF::RowPtr';
+  use_ok 'Bio::DB::HTS::VCF::Header';
+  use_ok 'Bio::DB::HTS::VCF::HeaderPtr';    
+}
 
 {
   # Test sweep functions
@@ -93,8 +99,6 @@ BEGIN { use_ok 'Bio::DB::HTS::VCF'; }
   is_deeply $info_result, [3], 'info ints read correctly';
   is $row->get_info_type($h,"NS"), "Integer", "info int type correct" ;
 
-  Bio::DB::HTS::VCF::Row->destroy($row) ;
-
   ok $row = $v->next(), "Next row";
   is $row->chromosome($h), "19", "Chromosome value read" ;
   is $row->position(), "112", "Position value read" ;
@@ -109,7 +113,6 @@ BEGIN { use_ok 'Bio::DB::HTS::VCF'; }
   is $row->has_filter($h,"PASS"), 1, "PASS Filter present" ;
   is $row->has_filter($h,"DP50"), 0, "Actual Filter absent" ;
   is $row->has_filter($h,"sdkjsdf"), -1, "Made up filter not existing" ;
-  Bio::DB::HTS::VCF::Row->destroy($row) ;
 
   #Format and genotype tests
   ok $row = $v->next(), "Next row";
@@ -172,8 +175,6 @@ BEGIN { use_ok 'Bio::DB::HTS::VCF'; }
   is_deeply $info_result, [3], 'info ints read correctly';
   is $row->get_info_type($h,"NS"), "Integer", "info int type correct" ;
 
-  Bio::DB::HTS::VCF::Row->destroy($row) ;
-
   ok $row = $v->next(), "Next row";
   is $row->chromosome($h), "19", "Chromosome value read" ;
   is $row->position(), "112", "Position value read" ;
@@ -188,7 +189,6 @@ BEGIN { use_ok 'Bio::DB::HTS::VCF'; }
   is $row->has_filter($h,"PASS"), 1, "PASS Filter present" ;
   is $row->has_filter($h,"DP50"), 0, "Actual Filter absent" ;
   is $row->has_filter($h,"sdkjsdf"), -1, "Made up filter not existing" ;
-  Bio::DB::HTS::VCF::Row->destroy($row) ;
 
   #Format and genotype tests
   ok $row = $v->next(), "Next row";

--- a/t/07cramwrite.t
+++ b/t/07cramwrite.t
@@ -54,10 +54,9 @@ use Bio::DB::HTS;
         $hts_file2->write1($header, $b);
         $count++;
     }
-    $hts_file2->close();
+    $hts_file2 = undef;
     ok( $count, 3307 );
 
-    $hts_file->close();
     $hts_file = Bio::DB::HTSfile->open( $cramfile );
     ok($hts_file);
 

--- a/t/08bamwrite.t
+++ b/t/08bamwrite.t
@@ -54,10 +54,9 @@ use Bio::DB::HTS;
         $hts_file2->write1($header, $b);
         $count++;
     }
-    $hts_file2->close();
+    $hts_file2 = undef;
     ok( $count, 3307 );
 
-    $hts_file->close();
     $hts_file = Bio::DB::HTSfile->open( $bamfile );
     ok($hts_file);
 

--- a/typemap
+++ b/typemap
@@ -9,7 +9,9 @@ Bio::DB::HTS::Tabix     T_PTROBJ
 Bio::DB::HTS::Tabix::Iterator T_PTROBJ
 Bio::DB::HTS::VCFfile         T_PTROBJ
 Bio::DB::HTS::VCF::Header     T_PTROBJ
+Bio::DB::HTS::VCF::HeaderPtr  T_PTROBJ
 Bio::DB::HTS::VCF::Row        T_PTROBJ
+Bio::DB::HTS::VCF::RowPtr     T_PTROBJ
 Bio::DB::HTS::VCF::Sweep      T_PTROBJ
 Bio::DB::HTS::Kseq::Iterator  T_PTROBJ
 Bio::DB::HTS::Kseq            T_PTROBJ


### PR DESCRIPTION
These methods will be called when their corresponding objects are
garbage collected. Adding these where needed to deallocate underlying
C objects and/or release resources.

Also remove "close" methods where possible to avoid these being called
where the objects may be referenced by multiple references and the
references may become dangling.

Also add Bio::DB::HTS::VCF::HeaderPtr and Bio::DB::HTS::VCF::RowPtr
packages to refer to a pointer object returned from C where it is just
a pointer to the underlying C object but does not own it (like in
vcf_sweep). Use the already existed Bio::DB::HTS::VCF::Header and
Bio::DB::HTS::VCF::Row for the objects that the pointers actually own
and are responsible for deallocation if needed.

Minor changes to test cases to accommodate the above changes.