### PR TITLE
 Implement -filter for features(-type=>'coverage')

### DIFF
--- a/lib/Bio/DB/HTS.pm
+++ b/lib/Bio/DB/HTS.pm
@@ -1936,9 +1936,6 @@ sub _coverage {
     my $self = shift;
     my ( $seqid, $start, $end, $bins, $filter ) = @_;
 
-    # Currently filter is ignored. In reality, we should
-    # turn filter into a callback and invoke it on each
-    # position in the pileup.
     croak "cannot calculate coverage unless a -seq_id is provided"
       unless defined $seqid;
 
@@ -1958,7 +1955,8 @@ sub _coverage {
     $bins ||= $end - $start + 1;
 
     my $index = $self->hts_index;
-    my $coverage = $index->coverage( $self->{hts_file}, $id, $s, $end, $bins );
+    my $coverage = $index->coverage( $self->{hts_file}, $id, $s, $end,
+                                     $bins, 8000, $filter );
 
     return
       Bio::SeqFeature::HTSCoverage->new( -display_name => "$seqid coverage",

--- a/lib/Bio/DB/HTS.xs
+++ b/lib/Bio/DB/HTS.xs
@@ -150,8 +150,12 @@ int hts_fetch_fun (void *data, bam1_t *b)
   callback     = fcp->callback;
   callbackdata = fcp->data;
 
-  /* turn the bam1_t into an appropriate object */
-  /* need to dup it here so that the C layer doesn't reuse the address under Perl */
+  /* The underlying bam1_t will be bam_destroy1()ed by alignment_obj's
+   * destructor, so we need to duplicate it here. We could create the Perl SV
+   * alongside the C bam1_t (cf bami_coverage), but note that a new b & b_sv
+   * would be needed for each iteration, as some callback functions will
+   * expect distinct references to distinct alignment objects each time.
+   */
   b2 = bam_dup1(b);
 
   alignment_obj = sv_setref_pv(newSV(sizeof(bam1_t)),"Bio::DB::HTS::Alignment",(void*) b2);

--- a/lib/Bio/DB/HTS.xs
+++ b/lib/Bio/DB/HTS.xs
@@ -194,6 +194,8 @@ int invoke_pileup_callback_fun(uint32_t tid,
 
   FREETMPS;
   LEAVE;
+
+  return 0;
 }
 
 /*
@@ -531,8 +533,10 @@ hts_read1(htsfile,header)
        if (sam_read1(htsfile,header,alignment) >= 0) {
          RETVAL = alignment ;
        }
-       else
+       else {
+         bam_destroy1(alignment);
          XSRETURN_EMPTY;
+       }
     OUTPUT:
        RETVAL
 
@@ -657,7 +661,7 @@ PREINIT:
     char* seq;
     int   i;
 CODE:
-    seq = Newxz(seq,b->core.l_qseq+1,char);
+    Newxz(seq,b->core.l_qseq+1,char);
     for (i=0;i<b->core.l_qseq;i++) {
       seq[i]=seq_nt16_str[bam_seqi(bam_get_seq(b),i)];
     }

--- a/lib/Bio/DB/HTS/Constants.pm
+++ b/lib/Bio/DB/HTS/Constants.pm
@@ -55,7 +55,7 @@ A hashref that maps flag values to human-readable names. For example:
 
 The reverse of FLAGS:
 
- FLAGS->{M_UNMAPPED} == 0x0008
+ RFLAGS->{M_UNMAPPED} == 0x0008
 
 =back
 

--- a/t/01bam.t
+++ b/t/01bam.t
@@ -18,7 +18,7 @@ use warnings;
 use ExtUtils::MakeMaker;
 use File::Temp qw(tempfile);
 use FindBin '$Bin';
-use constant TEST_COUNT => 364;
+use constant TEST_COUNT => 452;
 
 use lib "$Bin/../lib", "$Bin/../blib/lib", "$Bin/../blib/arch";
 
@@ -504,6 +504,36 @@ sub high_level_tests {
       ok($c);
       ok( $c->[0],            3 );
       ok( $c->[1],            4 );
+      ok( $c->[798],         50 );
+      ok( $c->[799],         49 );
+      ok( $c->[831],         46 );
+      ok( $c->[1300],        45 );
+      ok( $coverage[0]->type, "coverage:1584" );
+
+      # try filtered coverage (no filtering)
+      @coverage = $hts->features( -type => 'coverage', -seq_id => 'seq2', -filter => sub { return 1; } );
+      ok( scalar @coverage, 1 );
+      ($c) = $coverage[0]->get_tag_values('coverage');
+      ok($c);
+      ok( $c->[0],            3 );
+      ok( $c->[1],            4 );
+      ok( $c->[798],         50 );
+      ok( $c->[799],         49 );
+      ok( $c->[831],         46 );
+      ok( $c->[1300],        45 );
+      ok( $coverage[0]->type, "coverage:1584" );
+
+      # try filtered coverage (really filtering)
+      @coverage = $hts->features( -type => 'coverage', -seq_id => 'seq2', -filter => sub { my $a = shift; return defined $a->start && $a->start < 800 } );
+      ok( scalar @coverage, 1 );
+      ($c) = $coverage[0]->get_tag_values('coverage');
+      ok($c);
+      ok( $c->[0],            3 );
+      ok( $c->[1],            4 );
+      ok( $c->[798],         50 );
+      ok( $c->[799],         47 );
+      ok( $c->[831],          0 );
+      ok( $c->[1300],         0 );
       ok( $coverage[0]->type, "coverage:1584" );
 
       # test high level API version of pileup


### PR DESCRIPTION
At present, using `features(-type=>'coverage', -filter => sub { … })` ends up with your filter subroutine being silently ignored. This fixes that, implementing it as a filter that is called once for each **read** that (now optionally) goes into the pileup from which coverage is calculated.

Also some minor warning and leak fixes. This took rather longer than I anticipated as it took a long time to figure out what the `bam_dup1()` in `hts_fetch_fun()` was all about, so I have expanded on the comments there to hopefully clarify this.