### PR TITLE
Fix minor issue in POD

### DIFF
--- a/lib/Bio/DB/HTS.pm
+++ b/lib/Bio/DB/HTS.pm
@@ -222,6 +222,7 @@ follows:
  * Bio::DB::HTS::Pileup    -- Methods for manipulating the pileup data structure.
  * Bio::DB::HTS::Fai       -- Methods for creating and reading from indexed Fasta
                               files.
+
 =head1 METHODS
 
 We cover the high-level API first. The high-level API code can be


### PR DESCRIPTION
The added new line is needed to have the `=head1` as a header and not continuation of the previous text.