### PR TITLE
Documentation fixes

### DIFF
--- a/lib/Bio/DB/HTS.pm
+++ b/lib/Bio/DB/HTS.pm
@@ -868,9 +868,9 @@ methods:
 
  $pileup->is_refskip True if the base on the padded read is a gap relative to the reference (denoted as < or > in the pileup)
 
- $pileup->is_head Undocumented field in the bam.h header file.
+ $pileup->is_head True if this is the first base in the query sequence.
 
- $pileup->is_tail Undocumented field in the bam.h header file.
+ $pileup->is_tail True if this is the last base in the query sequence.
 
 See L</Examples> for a very simple SNP caller.
 
@@ -1265,10 +1265,11 @@ True if the base on the padded read is a gap relative to the reference (denoted 
 
 =item $flag = $pileup->is_head
 
-=item $flag = $pileup->is_del
+True if this is the first base in the query sequence.
 
-These fields are undocumented in the BAM documentation, but are
-exported to the Perl API just in case.
+=item $flag = $pileup->is_tail
+
+True if this is the last base in the query sequence.
 
 =back
 

--- a/lib/Bio/DB/HTS/Alignment.pm
+++ b/lib/Bio/DB/HTS/Alignment.pm
@@ -236,7 +236,7 @@ Return a reference to an array representing the CIGAR string. This is
 an array of arrays, in which each subarray consists of a CIGAR
 operation and a count. Example:
 
- [ ['M',34], ['D',1], ['M1',1] ]
+ [ ['M',34], ['D',1], ['M',1] ]
 
 =item ($ref,$matches,$query) = $align->padded_alignment
 


### PR DESCRIPTION
Upstream HTSlib now contains documentation of `is_head`/`is_tail`, which I've copied here. (It's not in the HTSlib 1.9 release, but is on **develop**.)