### PR TITLE
Yearly copyright update

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2015-2020] EMBL-European Bioinformatics Institute
+   Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README
+++ b/README
@@ -91,7 +91,7 @@ based on Bio::DB::Sam by Lincoln Stein
 
 ### COPYRIGHT
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS.pm
+++ b/lib/Bio/DB/HTS.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS.xs
+++ b/lib/Bio/DB/HTS.xs
@@ -1,5 +1,5 @@
 /*
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/AlignWrapper.pm
+++ b/lib/Bio/DB/HTS/AlignWrapper.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Alignment.pm
+++ b/lib/Bio/DB/HTS/Alignment.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Constants.pm
+++ b/lib/Bio/DB/HTS/Constants.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/Bio/DB/HTS/Faidx.pm
+++ b/lib/Bio/DB/HTS/Faidx.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Faidx.xs
+++ b/lib/Bio/DB/HTS/Faidx.xs
@@ -1,5 +1,5 @@
 /*
- * Copyright [2015-2020] EMBL-European Bioinformatics Institute
+ * Copyright [2015-2021] EMBL-European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/FetchIterator.pm
+++ b/lib/Bio/DB/HTS/FetchIterator.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Kseq.pm
+++ b/lib/Bio/DB/HTS/Kseq.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Kseq/Iterator.pod
+++ b/lib/Bio/DB/HTS/Kseq/Iterator.pod
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Kseq/Record.pm
+++ b/lib/Bio/DB/HTS/Kseq/Record.pm
@@ -2,7 +2,7 @@ package Bio::DB::HTS::Kseq::Record;
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Pileup.pm
+++ b/lib/Bio/DB/HTS/Pileup.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/PileupWrapper.pm
+++ b/lib/Bio/DB/HTS/PileupWrapper.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Query.pm
+++ b/lib/Bio/DB/HTS/Query.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/ReadIterator.pm
+++ b/lib/Bio/DB/HTS/ReadIterator.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Segment.pm
+++ b/lib/Bio/DB/HTS/Segment.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Tabix/Iterator.pm
+++ b/lib/Bio/DB/HTS/Tabix/Iterator.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/Target.pm
+++ b/lib/Bio/DB/HTS/Target.pm
@@ -1,7 +1,7 @@
 
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/VCF.pm
+++ b/lib/Bio/DB/HTS/VCF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/DB/HTS/VCF/Iterator.pm
+++ b/lib/Bio/DB/HTS/VCF/Iterator.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2015-2020] EMBL-European Bioinformatics Institute
+Copyright [2015-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/build_options.sh
+++ b/scripts/build_options.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/convert_gz_2_bgz.sh
+++ b/scripts/convert_gz_2_bgz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/00load.t
+++ b/t/00load.t
@@ -1,4 +1,4 @@
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/01bam.t
+++ b/t/01bam.t
@@ -1,5 +1,5 @@
 #-*-Perl-*-
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/02faidx.t
+++ b/t/02faidx.t
@@ -1,4 +1,4 @@
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/03cram.t
+++ b/t/03cram.t
@@ -1,6 +1,6 @@
 
 #-*-Perl-*-
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/04tabix.t
+++ b/t/04tabix.t
@@ -1,4 +1,4 @@
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/05vcf.t
+++ b/t/05vcf.t
@@ -1,4 +1,4 @@
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/06kseq.t
+++ b/t/06kseq.t
@@ -1,4 +1,4 @@
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/07cramwrite.t
+++ b/t/07cramwrite.t
@@ -1,5 +1,5 @@
 #-*-Perl-*-
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/08bamwrite.t
+++ b/t/08bamwrite.t
@@ -1,5 +1,5 @@
 #-*-Perl-*-
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/09sam.t
+++ b/t/09sam.t
@@ -1,5 +1,5 @@
 #-*-Perl-*-
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/10leak.t
+++ b/t/10leak.t
@@ -1,5 +1,5 @@
 #-*-Perl-*-
-# Copyright [2015-2020] EMBL-European Bioinformatics Institute
+# Copyright [2015-2021] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Yearly copyright update to include the new year.

## Use case

N/A

## Benefits

N/A

## Possible Drawbacks

N/A

## Testing

_Have you added/modified unit tests to test the changes?_

N/A

_If so, do the tests pass/fail?_

N/A.
Running greps on files confirms that all files have been updated accordingly:
```
$ cd Bio-DB-HTS
$ git checkout copyright-2021
$ git grep -l -P 'Copyright \[\d+-2021\]' | wc -l
      38
# as expected, there are no longer any files with a 2020 copyright end date
$ git grep -l -P 'Copyright \[\d+-2020\]' | wc -l
       0
# there are 2 extra files containing the word 'Copyright'
$ git grep -l -F 'Copyright' | wc -l
      40
# check that these 2 extra files did not need updating (see next steps)
# turns out these two extra files simply contain the string 'Copyright' and did not require updating
# here are my methods for clarity:
$ git grep -l -P 'Copyright \[\d+-2021\]' > 2021-file-list
$ git grep -l -F 'Copyright' > copyright-file-list
$ diff 2021-file-list copyright-file-list
1a2
> Changes
25a27
> ppport.h
$ grep 'Copyright' Changes
  * Copyright updates
$ grep 'Copyright' ppport.h
Version 3.x, Copyright (c) 2004-2009, Marcus Holland-Moritz.
Version 2.x, Copyright (C) 2001, Paul Marquess.
Version 1.x, Copyright (C) 1999, Kenneth Albanowski.
```

_Have you run the entire test suite and no regression was detected?_

The test build passes.