### PR TITLE
Decreasing Module::Build minimum dependency to 0.38

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -41,7 +41,7 @@ my $build = $class->new(
         '-Wno-unused-result',  ],
 
     build_requires => { 'ExtUtils::CBuilder' => 0, },
-    configure_requires => { 'Module::Build' => 0.42, },
+    configure_requires => { 'Module::Build' => 0.38, },
     requires => { 'perl' => '5.008', 'Bio::Root::Version' => '1.006001', },
     meta_merge => {
         'resources' => {

--- a/META.json
+++ b/META.json
@@ -21,7 +21,7 @@
       },
       "configure" : {
          "requires" : {
-            "Module::Build" : "0.42"
+            "Module::Build" : "0.38"
          }
       },
       "runtime" : {

--- a/META.yml
+++ b/META.yml
@@ -5,7 +5,7 @@ author:
 build_requires:
   ExtUtils::CBuilder: '0'
 configure_requires:
-  Module::Build: '0.42'
+  Module::Build: '0.38'
 dynamic_config: 1
 generated_by: 'Module::Build version 0.4224, CPAN::Meta::Converter version 2.150010'
 license: apache


### PR DESCRIPTION
This is a fix in response to issue [96](https://github.com/Ensembl/Bio-DB-HTS/issues/96)

When trying to install Bio::DB::HTS on a centos7 system, it breaks because of a Module::Build dependency which requires a minimum of 0.42. Decreasing that minimum to 0.38 is sufficient and leads to a successful installation. This change was added to the newest version, 3.01 and works fine. However, a VEP installation still uses version 2.11 of Bio::DB::HTS, and thus the same dependency issue is appearing when trying to install VEP on centos7.

This change applies the same fix in [#78](https://github.com/Ensembl/Bio-DB-HTS/issues/78) but does it on version 2.11. Installation of both Bio::DB::HTS independently and VEP was tested and everything seems to be working correctly.

Checks for perl 5.10 are failing due to a missing line in the travis config
`cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)`
which was added for release 3.01 but isn't in 2.11