### PR TITLE
Remove perl 5.10 testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: "perl"
 perl:
   - "5.26"
   - "5.14"
-  - "5.10"
 
 env:
   matrix:


### PR DESCRIPTION
Travis CI still runs tests on perl 5.10. However, we don't support that version anymore, perl 5.14 being the minimum supported one.