### PR TITLE
master branch has become main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 
 before_install:
     - git clone -b BioPerl-v1.7.4 --depth 1 https://github.com/bioperl/bioperl-live.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
+    - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-test.git
 
 install:
     - git clone --branch $HTSLIB_VERSION --depth=1 https://github.com/samtools/htslib.git

--- a/README
+++ b/README
@@ -3,7 +3,7 @@ This is a Perl interface to the HTS Library. See http://htslib.org
 Bio::DB::HTS supports a wide range of install configurations, with two scripts - Build.PL and INSTALL.pl.
 
 For a list of the ways it can be used, with examples in action see
-https://github.com/Ensembl/Bio-DB-HTS/blob/master/scripts/build_options.sh
+https://github.com/Ensembl/Bio-DB-HTS/blob/main/scripts/build_options.sh
 (link to scripts/build_options.sh in the Bio::DB::HTS GitHub repo at https://github.com/Ensembl/Bio-DB-HTS)
 
 ## ONE-STEP INSTALLATION (INSTALL.pl)

--- a/scripts/build_options.sh
+++ b/scripts/build_options.sh
@@ -17,7 +17,7 @@
 #
 # Script for testing/installing various build configurations of Bio::DB::HTS
 # $1 - clone command for Bio::DB::HTS from GitHub
-#    e.g. "git clone -b master https://github.com/Ensembl/Bio-DB-HTS.git"
+#    e.g. "git clone -b main https://github.com/Ensembl/Bio-DB-HTS.git"
 #    Set this to be an alternative clone command if required
 # $2 - the test to be run, to match one of the options below
 #


### PR DESCRIPTION
## Description

Master branches for EnsEMBL repos - in this case we are interested in ensembl-test - are being renamed as 'main'.
The .travis.yml file was not updated to reflect this change.
Also the README and a script file contained references to the EnsEMBL 'master' branch, although in comments or plain text.

## Use case

Travis CI/CD pipeline would break if .travis.yml is not fixed.

## Benefits

Can run CI/CD pipeline successfully

## Possible Drawbacks

N/A

## Testing

No
