### PR TITLE
TravisCI optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
 before_install:
     - cd $ENSDIR
     - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - $TRAVIS_BUILD_DIR
+    - cd $TRAVIS_BUILD_DIR
 
 install:
     - git clone --branch $HTSLIB_VERSION --recurse-submodules --shallow-submodules https://github.com/samtools/htslib.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,55 +1,54 @@
+dist: focal
+
 language: "perl"
 
 perl:
   - "5.26"
-  - "5.14"
+  - "5.32"
 
 env:
-  matrix:
-    - HTSLIB_VERSION=1.3.1
-    - HTSLIB_VERSION=1.5
-    - HTSLIB_VERSION=1.7
-    - HTSLIB_VERSION=1.8
-    - HTSLIB_VERSION=1.9
+  global:
+      - ENSDIR=$TRAVIS_BUILD_DIR/..
+      - COVERALLS="false"
+  jobs:
+      - HTSLIB_VERSION=1.9
+      - HTSLIB_VERSION=1.10
+      - HTSLIB_VERSION=1.11
+      - HTSLIB_VERSION=1.12
+      - HTSLIB_VERSION=1.13
 
 sudo: false
 
 addons:
-    apt:
-        packages:
-        - unzip
-        - liblzma-dev
-        - libbz2-dev
+  apt:
+    packages:
+      - unzip
+      - liblzma-dev
+      - libbz2-dev
+      - zlib1g-dev
+      - libcurl4-gnutls-dev
+      - libpng-dev
+      - libssl-dev
+      - openssl
+      - libexpat1-dev
 
 before_install:
-    - git clone -b BioPerl-v1.7.4 --depth 1 https://github.com/bioperl/bioperl-live.git
+    - cd $ENSDIR
     - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-test.git
+    - $TRAVIS_BUILD_DIR
 
 install:
-    - git clone --branch $HTSLIB_VERSION --depth=1 https://github.com/samtools/htslib.git
+    - git clone --branch $HTSLIB_VERSION --recurse-submodules --shallow-submodules https://github.com/samtools/htslib.git
     - cd htslib
     - make prefix=~/biodbhts install
     - export HTSLIB_DIR=
     - cd ..
-    # manually install items listed from cpanfile so we can skip BioPerl
-    - cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
-    - cpanm -f -n Carp
-    - cpanm -f -n Test::Most
-    - cpanm -f -n Test::LeakTrace
-    - cpanm -f -n Module::Build
-    - cpanm -f -n Log::Log4perl
-    - cpanm -f -n Try::Tiny
-    # - cpanm -v --installdeps --notest .
-    # install the modules just used here
-    - cpanm --notest Perl::Tidy
-    - cpanm --notest Test::Code::TidyAll
-    - export PERL5LIB=$PERL5LIB:$PWD/bioperl-live/lib
+    - cpanm -v --sudo --installdeps --notest .
     - perl Build.PL --prefix=~/biodbhts
     - ./Build
     - ./Build test
 
 script: "./travisci/harness.sh"
-
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
     - make prefix=~/biodbhts install
     - export HTSLIB_DIR=
     - cd ..
+    - cpanm -v --sudo --notest XML::LibXML # https://github.com/shlomif/perl-XML-LibXML/pull/87
     - cpanm -v --sudo --installdeps --notest .
     - perl Build.PL --prefix=~/biodbhts
     - ./Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
       - libssl-dev
       - openssl
       - libexpat1-dev
+      - libdb-dev
 
 before_install:
     - cd $ENSDIR

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+3.02
+  * HTSlib versions < 1.9 are deprecated and not supported anymore
+  * HTSlib supported versions: 1.9, 1.10, 1.11, 1.12, 1.13
+  * BioPerl minimum supported version is 1.6.924
 3.01
   * HTSlib 1.9 compatibility
   * CentOS 7 compatible installation, courtesy of John Marshall

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'Carp';
-requires 'Bio::Perl';
+requires 'Bio::Perl', '1.7.4';
 requires 'Log::Log4perl';
 requires 'Try::Tiny';
 requires 'Test::Most';

--- a/lib/Bio/DB/HTS.pm
+++ b/lib/Bio/DB/HTS.pm
@@ -1348,7 +1348,7 @@ L<http://search.cpan.org/dist/Bio-DB-HTS/>
 =cut
 
 package Bio::DB::HTS;
-$Bio::DB::HTS::VERSION = '3.01';
+$Bio::DB::HTS::VERSION = '3.02';
 
 use strict;
 use warnings;
@@ -2141,7 +2141,7 @@ sub _glob_match {
 
 package Bio::DB::HTS::Fai;
 
-$Bio::DB::HTS::Fai::VERSION = '3.01';
+$Bio::DB::HTS::Fai::VERSION = '3.02';
 
 sub open { shift->load(@_) }
 
@@ -2158,7 +2158,7 @@ package Bio::SeqFeature::HTSCoverage;
 
 use base 'Bio::SeqFeature::Lite';
 
-$Bio::SeqFeature::HTSCoverage::VERSION = '3.01';
+$Bio::SeqFeature::HTSCoverage::VERSION = '3.02';
 
 sub coverage {
     my $self = shift;
@@ -2190,7 +2190,7 @@ sub gff3_string {
 
 package Bio::DB::HTSfile;
 
-$Bio::DB::HTS::HTSfile::VERSION = '3.01';
+$Bio::DB::HTS::HTSfile::VERSION = '3.02';
 
 use File::Spec;
 use Cwd;

--- a/lib/Bio/DB/HTS/AlignWrapper.pm
+++ b/lib/Bio/DB/HTS/AlignWrapper.pm
@@ -56,7 +56,7 @@ Rishi Nag E<lt>rishi@ebi.ac.uk<gt>
 =cut
 
 package Bio::DB::HTS::AlignWrapper;
-$Bio::DB::HTS::AlignWrapper::VERSION = '3.01';
+$Bio::DB::HTS::AlignWrapper::VERSION = '3.02';
 
 use strict;
 use warnings;
@@ -452,7 +452,7 @@ sub tam_line {
 
 package Bio::DB::HTS::SplitAlignmentPart;
 
-$Bio::DB::HTS::SplitAlignmentPart::VERSION = '3.01';
+$Bio::DB::HTS::SplitAlignmentPart::VERSION = '3.02';
 
 use base 'Bio::SeqFeature::Lite';
 

--- a/lib/Bio/DB/HTS/Alignment.pm
+++ b/lib/Bio/DB/HTS/Alignment.pm
@@ -450,7 +450,7 @@ Rishi Nag E<lt>rishi@ebi.ac.uk<gt>
 =cut
 
 package Bio::DB::HTS::Alignment;
-$Bio::DB::HTS::Alignment::VERSION = '3.01';
+$Bio::DB::HTS::Alignment::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Constants.pm
+++ b/lib/Bio/DB/HTS/Constants.pm
@@ -70,7 +70,7 @@ L<Bio::Perl>, L<Bio::DB::HTS>, L<Bio::DB::Bam::Alignment>
 =cut
 
 package Bio::DB::HTS::Constants;
-$Bio::DB::HTS::Constants::VERSION = '3.01';
+$Bio::DB::HTS::Constants::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Faidx.pm
+++ b/lib/Bio/DB/HTS/Faidx.pm
@@ -80,7 +80,7 @@ our @EXPORT = qw(
 
 );
 
-our $VERSION = '3.01';
+our $VERSION = '3.02';
 
 require XSLoader;
 XSLoader::load('Bio::DB::HTS::Faidx', $VERSION);

--- a/lib/Bio/DB/HTS/FetchIterator.pm
+++ b/lib/Bio/DB/HTS/FetchIterator.pm
@@ -22,7 +22,7 @@ Rishi Nag E<lt>rishi@ebi.ac.uk<gt>
 =cut
 
 package Bio::DB::HTS::FetchIterator;
-$Bio::DB::HTS::FetchIterator::VERSION = '3.01';
+$Bio::DB::HTS::FetchIterator::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Kseq.pm
+++ b/lib/Bio/DB/HTS/Kseq.pm
@@ -71,7 +71,7 @@ package Bio::DB::HTS::Kseq;
 use Bio::DB::HTS; #load the XS
 use Bio::DB::HTS::Kseq::Record;
 
-$Bio::DB::HTS::Kseq::VERSION = '3.01';
+$Bio::DB::HTS::Kseq::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Kseq/Record.pm
+++ b/lib/Bio/DB/HTS/Kseq/Record.pm
@@ -56,7 +56,7 @@ The quality string from a FASTA/Q record
 use strict;
 use warnings;
 
-$Bio::DB::HTS::Kseq::Record::VERSION = '3.01';
+$Bio::DB::HTS::Kseq::Record::VERSION = '3.02';
 
 sub name {
   return $_[0]->{name};

--- a/lib/Bio/DB/HTS/Pileup.pm
+++ b/lib/Bio/DB/HTS/Pileup.pm
@@ -99,6 +99,6 @@ package Bio::DB::HTS::Pileup;
 use strict;
 use warnings;
 
-$Bio::DB::HTS::Pileup::VERSION = '3.01';
+$Bio::DB::HTS::Pileup::VERSION = '3.02';
 
 1;

--- a/lib/Bio/DB/HTS/PileupWrapper.pm
+++ b/lib/Bio/DB/HTS/PileupWrapper.pm
@@ -41,7 +41,7 @@ L<Bio::Perl>, L<Bio::DB::HTS>, L<Bio::DB::HTS::Constants>
 =cut
 
 package Bio::DB::HTS::PileupWrapper;
-$Bio::DB::HTS::PileupWrapper::VERSION = '3.01';
+$Bio::DB::HTS::PileupWrapper::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Query.pm
+++ b/lib/Bio/DB/HTS/Query.pm
@@ -48,7 +48,7 @@ part of a SAM alignment.
 =cut
 
 package Bio::DB::HTS::Query;
-$Bio::DB::HTS::Query::VERSION = '3.01';
+$Bio::DB::HTS::Query::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/ReadIterator.pm
+++ b/lib/Bio/DB/HTS/ReadIterator.pm
@@ -22,7 +22,7 @@ Rishi Nag E<lt>rishi@ebi.ac.uk<gt>
 =cut
 
 package Bio::DB::HTS::ReadIterator;
-$Bio::DB::HTS::ReadIterator::VERSION = '3.01';
+$Bio::DB::HTS::ReadIterator::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Segment.pm
+++ b/lib/Bio/DB/HTS/Segment.pm
@@ -22,7 +22,7 @@ Rishi Nag E<lt>rishi@ebi.ac.uk<gt>
 =cut
 
 package Bio::DB::HTS::Segment;
-$Bio::DB::HTS::Segment::VERSION = '3.01';
+$Bio::DB::HTS::Segment::VERSION = '3.02';
 
 use strict;
 use warnings;
@@ -122,7 +122,7 @@ sub class { 'sequence' }
 
 package Bio::DB::HTS::Segment::Iterator;
 
-$Bio::DB::HTS::Segment::Iterator::VERSION = '3.01';
+$Bio::DB::HTS::Segment::Iterator::VERSION = '3.02';
 
 sub new {
     my $package  = shift;

--- a/lib/Bio/DB/HTS/Tabix.pm
+++ b/lib/Bio/DB/HTS/Tabix.pm
@@ -21,7 +21,7 @@ package Bio::DB::HTS::Tabix;
 
 use Bio::DB::HTS;
 use Bio::DB::HTS::Tabix::Iterator;
-$Bio::DB::HTS::Tabix::VERSION = '3.01';
+$Bio::DB::HTS::Tabix::VERSION = '3.02';
 use strict;
 use warnings;
 

--- a/lib/Bio/DB/HTS/Tabix/Iterator.pm
+++ b/lib/Bio/DB/HTS/Tabix/Iterator.pm
@@ -19,7 +19,7 @@ limitations under the License.
 package Bio::DB::HTS::Tabix::Iterator;
 
 use Bio::DB::HTS; #load the XS
-$Bio::DB::HTS::Tabix::Iterator::VERSION = '3.01';
+$Bio::DB::HTS::Tabix::Iterator::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/Target.pm
+++ b/lib/Bio/DB/HTS/Target.pm
@@ -33,7 +33,7 @@ Rishi Nag E<lt>rishi@ebi.ac.uk<gt>
 =cut
 
 package Bio::DB::HTS::Target;
-$Bio::DB::HTS::Target::VERSION = '3.01';
+$Bio::DB::HTS::Target::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/VCF.pm
+++ b/lib/Bio/DB/HTS/VCF.pm
@@ -403,7 +403,7 @@ so using the next() function is preferable to using sweeps.
 =cut
 
 package Bio::DB::HTS::VCF;
-$Bio::DB::HTS::VCF::VERSION = '3.01';
+$Bio::DB::HTS::VCF::VERSION = '3.02';
 
 use Bio::DB::HTS;
 use Scalar::Util qw/reftype/;
@@ -507,7 +507,7 @@ sub DESTROY {
 }
 
 package Bio::DB::HTS::VCF::Sweep ;
-$Bio::DB::HTS::VCF::Sweep::VERSION = '3.01';
+$Bio::DB::HTS::VCF::Sweep::VERSION = '3.02';
 
 use Bio::DB::HTS;
 use Scalar::Util qw/reftype/;

--- a/lib/Bio/DB/HTS/VCF/Header.pm
+++ b/lib/Bio/DB/HTS/VCF/Header.pm
@@ -2,6 +2,6 @@ package Bio::DB::HTS::VCF::Header;
 
 use Bio::DB::HTS; #load the XS
 
-$Bio::DB::HTS::VCF::Header::VERSION = '3.01';
+$Bio::DB::HTS::VCF::Header::VERSION = '3.02';
 
 1;

--- a/lib/Bio/DB/HTS/VCF/HeaderPtr.pm
+++ b/lib/Bio/DB/HTS/VCF/HeaderPtr.pm
@@ -2,7 +2,7 @@ package Bio::DB::HTS::VCF::HeaderPtr;
 
 use base Bio::DB::HTS::VCF::Header;
 
-$Bio::DB::HTS::VCF::HeaderPtr::VERSION = '3.01';
+$Bio::DB::HTS::VCF::HeaderPtr::VERSION = '3.02';
 
 sub DESTROY {
     # do nothing (overwrite subroutine in base class)

--- a/lib/Bio/DB/HTS/VCF/Iterator.pm
+++ b/lib/Bio/DB/HTS/VCF/Iterator.pm
@@ -19,7 +19,7 @@ limitations under the License.
 package Bio::DB::HTS::VCF::Iterator;
 
 use Bio::DB::HTS; #load the XS
-$Bio::DB::HTS::VCF::Iterator::VERSION = '3.01';
+$Bio::DB::HTS::VCF::Iterator::VERSION = '3.02';
 
 use strict;
 use warnings;

--- a/lib/Bio/DB/HTS/VCF/Row.pm
+++ b/lib/Bio/DB/HTS/VCF/Row.pm
@@ -1,6 +1,6 @@
 package Bio::DB::HTS::VCF::Row;
 
-$Bio::DB::HTS::VCF::Row::VERSION = '3.01';
+$Bio::DB::HTS::VCF::Row::VERSION = '3.02';
 
 use Bio::DB::HTS;
 

--- a/lib/Bio/DB/HTS/VCF/RowPtr.pm
+++ b/lib/Bio/DB/HTS/VCF/RowPtr.pm
@@ -2,7 +2,7 @@ package Bio::DB::HTS::VCF::RowPtr;
 
 use base Bio::DB::HTS::VCF::Row;
 
-$Bio::DB::HTS::VCF::RowPtr::VERSION = '3.01';
+$Bio::DB::HTS::VCF::RowPtr::VERSION = '3.02';
 
 sub DESTROY {
     # do nothing (overwrite subroutine in base class)

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-export PERL5LIB=$PERL5LIB:$PWD/ensembl-test/modules:$PWD/lib:$PWD/blib/arch/auto/Bio/DB/HTS/:$PWD/blib/arch/auto/Bio/DB/HTS/Faidx
+
+ENSDIR="${ENSDIR:-$PWD}"
+
+export PERL5LIB=$ENSDIR/ensembl-test/modules:$PWD/lib:$PWD/blib/arch/auto/Bio/DB/HTS/:$PWD/blib/arch/auto/Bio/DB/HTS/Faidx
 
 export TEST_AUTHOR=$USER
-
-export WORK_DIR=$PWD
 
 echo "Running test suite"
 echo "Using PERL5LIB:$PERL5LIB"
@@ -17,8 +18,7 @@ ls -l t
 echo "COVERALLS value=$COVERALLS"
 echo "HTSLIB_VERSION value=$HTSLIB_VERSION"
 
-perl $PWD/ensembl-test/scripts/runtests.pl t $SKIP_TESTS
-
+perl $ENSDIR/ensembl-test/scripts/runtests.pl t $SKIP_TESTS
 
 rt=$?
 if [ $rt -eq 0 ]; then


### PR DESCRIPTION
## Description

- Deprecation of HTSlib < 1.9
- Added tests for HTSlib versions up to 1.13
- Use of `focal` images for testing ([build environment](https://docs.travis-ci.com/user/reference/focal/#perl-support))
- Deprecation of Perl 5.14
- Added Perl 5.32 in lieu of 5.14
- Moved Perl deps to `cpanfile`
   - Exception: XML::LibXML tests contain bugs - see https://github.com/shlomif/perl-XML-LibXML/pull/87
- Patched `harness.sh`
- Bumped up Bio::DB::HTS version to 3.02

## Use case

Minor optimisations and deprecation of legacy stuff

## Benefits

Better tracking and handling of Perl dependencies.
Better support and checking new(er) libraries.

## Possible Drawbacks

None

## Testing

No tests were updated or added.
Test suite could run successfully